### PR TITLE
Introduce exclusive player states

### DIFF
--- a/lib/game/model/act_checkgameover.go
+++ b/lib/game/model/act_checkgameover.go
@@ -14,22 +14,6 @@ func (act *ActionCheckGameOver) Apply(game *Game) ([]Event, error) {
 	return nil, nil
 }
 
-// checkAlive returns true if player p is still alive in game g. An alive
-// player has control of at least one island or airplane.
-func checkAlive(g *Game, p *Player) bool {
-	for _, island := range g.Islands() {
-		if island.Owner().Equals(p) {
-			return true
-		}
-	}
-	for _, airplane := range g.Airplanes() {
-		if airplane.Owner().Equals(p) {
-			return true
-		}
-	}
-	return false
-}
-
 // isGameOver checks if the current game is over. A game is over when less than
 // two players are still alive.
 // If only a single player is alive, then that player is returned as the
@@ -38,14 +22,9 @@ func checkAlive(g *Game, p *Player) bool {
 func isGameOver(g *Game) (gameOver bool, winner *Player) {
 	alivePlayers := make([]*Player, 0)
 	for _, player := range g.Players() {
-		if !player.IsAlive() {
-			continue
+		if player.State() == Alive {
+			alivePlayers = append(alivePlayers, player)
 		}
-		if !checkAlive(g, player) {
-			player.SetAlive(false)
-			continue
-		}
-		alivePlayers = append(alivePlayers, player)
 	}
 	if len(alivePlayers) == 0 {
 		return true, nil

--- a/lib/game/model/act_leave.go
+++ b/lib/game/model/act_leave.go
@@ -43,6 +43,6 @@ func (a *actionLeave) Apply(game *Game) ([]Event, error) {
 			airplane.SetOwner(neutralPlayer)
 		}
 	}
-	leavingPlayer.SetHasLeft(true)
+	leavingPlayer.SetState(LeftGame)
 	return nil, nil
 }

--- a/lib/game/model/game.go
+++ b/lib/game/model/game.go
@@ -9,6 +9,9 @@ import (
 type Game struct {
 	id   GameID
 	size Coordinate
+
+	reviveCount int
+
 	// playerNeutral is a special Player that owns everything not
 	// owned by any other Player.
 	playerNeutral *Player
@@ -25,6 +28,16 @@ func (g *Game) ID() GameID {
 // Size is a getter for the size of the game.
 func (g *Game) Size() Coordinate {
 	return g.size
+}
+
+// ReviveCount returns how many times players have been revived this game.
+func (g *Game) ReviveCount() int {
+	return g.reviveCount
+}
+
+// SetReviveCount sets how many times players have been revivied this game.
+func (g *Game) SetReviveCount(reviveCount int) {
+	g.reviveCount = reviveCount
 }
 
 // PlayerNeutral is a getter for the Player model representing the neutral

--- a/lib/game/model/player.go
+++ b/lib/game/model/player.go
@@ -1,13 +1,29 @@
 package model
 
+// A PlayerState represents the current exclusive state of a Player.
+// During a game a Player transitions between PlayerStates:
+//
+//   Alive <-> PendingRevival -> Dead
+//   |             v             |
+//   ---------> LeftGame <--------
+//
+type PlayerState int
+
+const (
+	// Alive is when still alive in the game.
+	Alive PlayerState = iota
+	// PendingRevival is when dead, but may be revived.
+	PendingRevival
+	// Dead is when dead and will remain dead.
+	Dead
+	// LeftGame is when the Player has left the game.
+	LeftGame
+)
+
 // Player represents a player in the game model.
 type Player struct {
-	id PlayerID
-	// alive is set false when the player is no longer alive in the game. Used
-	// to short-circuit logic that only applies to alive players.
-	alive bool
-	// hasLeft is set true if the player leaves the game.
-	hasLeft bool
+	id    PlayerID
+	state PlayerState
 	// fogOfWar is a set of coordinates for tiles where the player has Fog of
 	// War (limited) vision.
 	fogOfWar map[Coordinate]struct{}
@@ -18,7 +34,7 @@ func NewPlayer() (*Player, error) {
 	id := PlayerID(NextModelID())
 	return &Player{
 		id:       id,
-		alive:    true,
+		state:    Alive,
 		fogOfWar: nil,
 	}, nil
 }
@@ -28,25 +44,14 @@ func (p *Player) ID() PlayerID {
 	return p.id
 }
 
-// IsAlive returns the alive state of the player, i.e. if the player is still
-// alive in the game.
-func (p *Player) IsAlive() bool {
-	return p.alive
+// State returns the current state of the player.
+func (p *Player) State() PlayerState {
+	return p.state
 }
 
-// SetAlive sets the alive state of the player.
-func (p *Player) SetAlive(alive bool) {
-	p.alive = alive
-}
-
-// HasLeft returns true if the player has left the game.
-func (p *Player) HasLeft() bool {
-	return p.hasLeft
-}
-
-// SetHasLeft sets the flag for if the player has left the game.
-func (p *Player) SetHasLeft(hasLeft bool) {
-	p.hasLeft = hasLeft
+// SetState sets the current state of the player.
+func (p *Player) SetState(state PlayerState) {
+	p.state = state
 }
 
 // IsInFogOfWar tests if the given Coordinate is in fog of war for the player.
@@ -80,7 +85,7 @@ func (p *Player) Copy() *Player {
 	}
 	return &Player{
 		id:       p.id,
-		alive:    p.alive,
+		state:    p.state,
 		fogOfWar: fogOfWar,
 	}
 }


### PR DESCRIPTION
Instead of the player having a bunch of getters for various states that
was implicitly exclusive, this commit adds a PlayerState to each Player.

This commit also moves checking of player alive to the tick action. The
check for game over is still performed in the check game over action.

This commit makes it fairly obvious that the tick action is a very
central part of the game and should probably be rethought in the future.