### PR TITLE
Add AI opponents

### DIFF
--- a/lib/game/ai/client.go
+++ b/lib/game/ai/client.go
@@ -1,0 +1,151 @@
+package ai
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/verath/archipelago/lib/common"
+	"github.com/verath/archipelago/lib/game/model"
+	"golang.org/x/time/rate"
+)
+
+const (
+	// clientActionLimitRate is the rate limit bucket refill rate [token/s], limiting
+	// the number of actions the client is allowed to take per second on average.
+	clientActionLimitRate = rate.Limit(1)
+
+	// clientActionLimitBurst is the rate limit bucket size, limiting the burst number
+	// number of actions that the client is allowed to take.
+	clientActionLimitBurst = 10
+)
+
+type clientState struct {
+	// myPlayerID is the PlayerID that the client represents in the game model.
+	myPlayerID model.PlayerID
+}
+
+// Client is an "ai" controlled client that listens for game events and
+// produces actions in response. The actions are chosen by the selected
+// strategy.
+type Client struct {
+	logEntry *logrus.Entry
+
+	strategy strategy
+
+	stateMu sync.Mutex
+	state   clientState
+
+	limiter *rate.Limiter
+
+	actionCh chan model.PlayerAction
+
+	disconnectOnce sync.Once
+	disconnectCh   chan struct{}
+}
+
+// NewClient creates a new AI Client using the provided strategy.
+func NewClient(log *logrus.Logger, strategyCreator StrategyCreatorFunc) (*Client, error) {
+	if strategyCreator == nil {
+		panic("strategyCreator == nil")
+	}
+	logEntry := common.ModuleLogEntryWithID(log, "ai/client")
+	strategy, err := strategyCreator()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating strategy")
+	}
+	return &Client{
+		logEntry:     logEntry,
+		strategy:     strategy,
+		limiter:      rate.NewLimiter(clientActionLimitRate, clientActionLimitBurst),
+		actionCh:     make(chan model.PlayerAction, 1),
+		disconnectCh: make(chan struct{}, 0),
+	}, nil
+}
+
+// Disconnect disconnects the Client, closing the DisconnectCh and unblocking
+// and Read calls.
+func (c *Client) Disconnect() {
+	c.disconnectOnce.Do(func() {
+		c.logEntry.Debug("Disconnect")
+		close(c.disconnectCh)
+	})
+}
+
+// DisconnectCh returns a channel closed when the Client is disconnected. For
+// the AI Client, this channel is only closed as a result of a call to
+// Disconnect.
+func (c *Client) DisconnectCh() <-chan struct{} {
+	return c.disconnectCh
+}
+
+// WritePlayerEvent "writes" a player event to the AI Client, which will be
+// used to produce new actions by the client.
+func (c *Client) WritePlayerEvent(ctx context.Context, playerEvent model.PlayerEvent) error {
+	switch evt := playerEvent.(type) {
+	case *model.PlayerEventGameStart:
+		return c.onGameStart(ctx, evt)
+	case *model.PlayerEventTick:
+		return c.onTick(ctx, evt)
+	case *model.PlayerEventGameOver:
+		return c.onGameOver(ctx, evt)
+	default:
+		return errors.Errorf("unexpected playerEvent type %T", playerEvent)
+	}
+}
+
+// ReadPlayerAction returns the next action that the AI Client wants to apply
+// on the game.
+func (c *Client) ReadPlayerAction(ctx context.Context) (model.PlayerAction, error) {
+	select {
+	case act := <-c.actionCh:
+		return act, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.disconnectCh:
+		return nil, errors.New("Disconnected")
+	}
+}
+
+func (c *Client) onGameStart(ctx context.Context, evt *model.PlayerEventGameStart) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.state.myPlayerID = evt.PlayerID
+	c.logEntry.WithField("myPlayerId", c.state.myPlayerID).Debug("onGameStart")
+	return nil
+}
+
+func (c *Client) onGameOver(ctx context.Context, evt *model.PlayerEventGameOver) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.state.myPlayerID = model.PlayerID(model.InvalidID)
+	c.logEntry.WithField("myPlayerId", c.state.myPlayerID).Debug("onGameOver")
+	return nil
+}
+
+func (c *Client) onTick(ctx context.Context, evt *model.PlayerEventTick) error {
+	// Rate limit and add 50% do nothing, do prevent multiple instances to
+	// perform actions as the same time.
+	if !c.limiter.Allow() || rand.Intn(10) < 5 {
+		return nil
+	}
+	// Delegate to strategy to perform next action.
+	// TODO: This somewhat locks the strategy to the tick rate, probably
+	// not ideal...
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	act, err := c.strategy.NextAction(c.state, evt.Game)
+	if err != nil {
+		errors.Wrap(err, "failed getting next action from strategy")
+	}
+	if act != nil {
+		select {
+		case c.actionCh <- act:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}

--- a/lib/game/ai/strategy.go
+++ b/lib/game/ai/strategy.go
@@ -1,0 +1,165 @@
+package ai
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+
+	"github.com/verath/archipelago/lib/game/model"
+)
+
+// A strategy is an "AI" strategy, or behavior. It controlls how the ai should
+// act.
+type strategy interface {
+	// NextAction returns the next action to be performed, given the current
+	// ai client state and game.
+	// The returned action may be nil, to indicate that the strategy could not
+	// determine a next action.
+	NextAction(state clientState, game *model.Game) (model.PlayerAction, error)
+}
+
+// StrategyCreatorFunc is a function that returns an AI strategy, hiding the
+// strategy interface.
+type StrategyCreatorFunc func() (strategy, error)
+
+// RandomStrategy launches airplanes at (mostly) random.
+func RandomStrategy(minOriginStrength int64) StrategyCreatorFunc {
+	return func() (strategy, error) {
+		return newRandomStrategy(minOriginStrength)
+	}
+}
+
+// OpportunisticStrategy tries to launch airplanes only to islands that it can
+// conquer.
+func OpportunisticStrategy() StrategyCreatorFunc {
+	return func() (strategy, error) {
+		return newOpportunisticStrategy()
+	}
+}
+
+type randomStrategy struct {
+	minOriginStrength int64
+}
+
+func newRandomStrategy(minOriginStrength int64) (*randomStrategy, error) {
+	if minOriginStrength < 2 {
+		return nil, errors.New("minOriginStrength must be >= 2")
+	}
+	return &randomStrategy{
+		minOriginStrength: minOriginStrength,
+	}, nil
+}
+
+func (s *randomStrategy) NextAction(state clientState, game *model.Game) (model.PlayerAction, error) {
+	myPlayer := game.Player(state.myPlayerID)
+	if myPlayer == nil {
+		return nil, errors.New("myPlayer not found in game")
+	}
+	// Select random owned island with at least minOriginStrength.
+	myIslands := islandsBy(game, func(island *model.Island) bool {
+		return island.IsOwnedBy(myPlayer) && island.Strength() >= s.minOriginStrength
+	})
+	if len(myIslands) == 0 {
+		return nil, nil
+	}
+	originIsland := myIslands[rand.Intn(len(myIslands))]
+	// Select random target island.
+	otherIslands := islandsNotOwnedBy(game, myPlayer)
+	if len(otherIslands) == 0 {
+		return nil, nil
+	}
+	targetIsland := otherIslands[rand.Intn(len(otherIslands))]
+	// Create the action.
+	act := &model.PlayerActionLaunch{
+		From: originIsland.ID(),
+		To:   targetIsland.ID(),
+	}
+	return act, nil
+}
+
+type opportunisticStrategy struct {
+	// failed is a counter for the number of consecutive time the strategy
+	// failed to take action.
+	failed int64
+}
+
+func newOpportunisticStrategy() (*opportunisticStrategy, error) {
+	return &opportunisticStrategy{}, nil
+}
+
+func (s *opportunisticStrategy) NextAction(state clientState, game *model.Game) (act model.PlayerAction, err error) {
+	// Keep count of how many times we fail to perform an action.
+	defer func() {
+		if act == nil {
+			s.failed++
+		} else {
+			s.failed = 0
+		}
+	}()
+
+	myPlayer := game.Player(state.myPlayerID)
+	if myPlayer == nil {
+		return nil, errors.New("myPlayer not found in game")
+	}
+
+	// Select one of our islands.
+	myIslands := islandsBy(game, func(island *model.Island) bool {
+		return island.IsOwnedBy(myPlayer) && island.Strength() >= 2
+	})
+	ownedRatio := float64(len(myIslands)) / float64(len(game.Islands()))
+	if len(myIslands) == 0 {
+		return nil, nil
+	}
+	originIsland := myIslands[rand.Intn(len(myIslands))]
+
+	// Target any other island "weaker" than this island.
+	weakerIslands := islandsBy(game, func(island *model.Island) bool {
+		if island.IsOwnedBy(myPlayer) {
+			return false
+		}
+		islandStrength := island.Strength()
+		// Island is in FoW, make a guess about its strength.
+		if islandStrength < 0 {
+			islandStrength = int64(40 * float64(island.Size()))
+		}
+		// Punish attacking neutral islands.
+		if island.IsOwnedBy(game.PlayerNeutral()) {
+			islandStrength *= 2
+		}
+		// Punish distance.
+		distX := originIsland.Position().X - island.Position().X
+		distY := originIsland.Position().Y - island.Position().Y
+		islandStrength += int64(math.Hypot(float64(distX), float64(distY)))
+		// Make the action increasingly more attractive for each time we don't
+		// make a move, especially if we control a lot of islands.
+		islandStrength -= int64(float64(s.failed) * ownedRatio)
+		return islandStrength < originIsland.Strength()
+	})
+	if len(weakerIslands) == 0 {
+		return nil, nil
+	}
+	targetIsland := weakerIslands[rand.Intn(len(weakerIslands))]
+
+	// Create the action.
+	act = &model.PlayerActionLaunch{
+		From: originIsland.ID(),
+		To:   targetIsland.ID(),
+	}
+	return act, nil
+}
+
+func islandsBy(game *model.Game, pred func(*model.Island) bool) []*model.Island {
+	islands := make([]*model.Island, 0)
+	for _, island := range game.Islands() {
+		if pred(island) {
+			islands = append(islands, island)
+		}
+	}
+	return islands
+}
+
+func islandsNotOwnedBy(game *model.Game, player *model.Player) []*model.Island {
+	return islandsBy(game, func(island *model.Island) bool {
+		return !island.IsOwnedBy(player)
+	})
+}


### PR DESCRIPTION
The AI opponents are implemented as Clients, functioning in the same way
as remote clients but short-circuiting the need to transfer events and
actions over the wire. Currently the AI Client performs zero or one
action per event, which means it is tied to the game loop tick interval.

The behavior of a Client is controlled by a "strategy". There are
currently two strategies, one that simply sends at random, and one that
tries to be a bit more clever. Neither strategy has any understanding of
past event.